### PR TITLE
Remove unnecessary set of FindBoost CMake options

### DIFF
--- a/.github/.gitpod.Dockerfile
+++ b/.github/.gitpod.Dockerfile
@@ -1,0 +1,12 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+RUN sudo apt-get -q update && \
+    sudo apt-get install -yq libboost-all-dev 
+#     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.github/.gitpod.yml
+++ b/.github/.gitpod.yml
@@ -1,0 +1,12 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: echo 'init script' # runs during prebuild
+    command: echo 'start script'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,6 @@ include(GNUInstallDirs)
 option(COMPILE_WITHYARP_DEF "Compile diagnosticdaemon for YARP connection" OFF)
 option(DIAGNOSTICDAEMON_USE_EXTERNAL_PUGIXML "Set to on if you want to use an external pugixml" OFF)
 
-set(Boost_NO_BOOST_CMAKE ON)
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREAD ON)
-
 find_package(Boost 1.65.0 REQUIRED)
 find_package(icub_firmware_shared REQUIRED)
 if(icub_firmware_shared_FOUND)

--- a/src/diagnosticdaemoncore/ComponentYarpLogger.cpp
+++ b/src/diagnosticdaemoncore/ComponentYarpLogger.cpp
@@ -32,10 +32,10 @@ void ComponentYarpLogger::acceptMsg(std::array<uint8_t,maxMsgLenght_>&,unsigned 
     Log(Severity::error)<<"Todo"<<std::endl;
 }
 
+
+#ifdef COMPILE_WITHYARP_DEF
 void ComponentYarpLogger::forewardtoYarpLogger(const std::string& data,Severity severity)
 {
-    severity=severity;
-#ifdef COMPILE_WITHYARP_DEF
     switch (severity)
     {
         case Severity::info:
@@ -55,5 +55,8 @@ void ComponentYarpLogger::forewardtoYarpLogger(const std::string& data,Severity 
             yFatal()<<data;;
             break;
     }
-#endif    
+
 }
+#else
+void ComponentYarpLogger::forewardtoYarpLogger(const std::string& ,Severity ){};
+#endif    


### PR DESCRIPTION
An open source project that is meant to be built with several package manager that provide its dependencies should not set any Boost_** related CMake variables, because (for example) if someone wants to build it with a static Boost version it should be possible to do so.